### PR TITLE
Bugfix/crm 1879-Incorrect total for summary field

### DIFF
--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -2348,7 +2348,6 @@ LEFT JOIN civicrm_contact {$prop['alias']} ON {$prop['alias']}.id = {$this->_ali
       $this->_noGroupBY = TRUE;
       return;
     }
-    $this->_select = "SELECT {$selectedField['dbAlias']} as $fieldAlias ";
      //CRM-1879- This condition should applicable only for contribution_page_id
     if(($selectedField['dbAlias']) == 'contribution.contribution_page_id')
     {

--- a/CRM/Extendedreport/Form/Report/ExtendedReport.php
+++ b/CRM/Extendedreport/Form/Report/ExtendedReport.php
@@ -1807,7 +1807,13 @@ class CRM_Extendedreport_Form_Report_ExtendedReport extends CRM_Report_Form {
         $where = "Where " . $rowFields[0]['dbAlias'] . " = " . $rowFieldId;
       }
       elseif (!empty($rowFieldId) && is_string($rowFieldId) && $rowFieldId !== 'HEADER') {
-        $where = "Where " . $rowFields[0]['dbAlias'] . " LIKE '%" . $rowFieldId . "%'";
+       // CRM-1879-Incorrect total for summary field- added 'Unassigned' rowField ID for contributions with contributions page id 'NULL'
+        if($rowFieldId == 'Unassigned')
+        {
+          $where = "Where " . $rowFields[0]['dbAlias'] . " IS NULL ";
+        }else{
+          $where = "Where " . $rowFields[0]['dbAlias'] . " LIKE '%" . $rowFieldId . "%'";
+        }
       }
 
       // Custom fields join.
@@ -2343,6 +2349,13 @@ LEFT JOIN civicrm_contact {$prop['alias']} ON {$prop['alias']}.id = {$this->_ali
       return;
     }
     $this->_select = "SELECT {$selectedField['dbAlias']} as $fieldAlias ";
+     //CRM-1879- This condition should applicable only for contribution_page_id
+    if(($selectedField['dbAlias']) == 'contribution.contribution_page_id')
+    {
+      $this->_select = "SELECT  ( CASE WHEN {$selectedField['dbAlias']} IS NULL THEN 'Unassigned' ELSE {$selectedField['dbAlias']} END ) as $fieldAlias ";
+    }else{
+      $this->_select = "SELECT {$selectedField['dbAlias']} as $fieldAlias ";
+    }
     if (!in_array($fieldAlias, $this->_groupByArray, TRUE)) {
       $this->_groupByArray[] = $fieldAlias;
     }
@@ -6403,7 +6416,13 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
    * @return mixed
    */
   function alterContributionPage($value) {
-    $title = CRM_Contribute_PseudoConstant::contributionPage($value);
+    //CRM-1879- for unassigned fund gave title 'Unassigned Fund'
+     if($value == 'Unassigned')
+     {
+       $title = 'Unassigned Fund';
+     }else{
+      $title = CRM_Contribute_PseudoConstant::contributionPage($value,TRUE);
+    }
     return $title;
   }
 


### PR DESCRIPTION
Incorrect total for summary fields was incorrect because while considering the grand total for campaigns, the system was not considering contributions under the unassigned fund. That was the reason there was a discrepancy between the total amount of contributions and grand total of contributions.

With the following solution, we have added an additional row under the name of 'Unassigned Funds' which shows all contributions which are associated with contribution_page_id = NULL. Which will sum up the total values.